### PR TITLE
Enhance pagination to make next page visible before ellipsis

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -86,6 +86,11 @@ const Pagination = ({
         for (let i = 1; i <= 3; i++) {
           pages.push(i);
         }
+
+        if (page === 3 && page + 1 <= totalPages - 2) {
+          pages.push(page + 1);
+        }
+        
         if (totalPages > 4) {
           pages.push(-1);
         }

--- a/tests/components/Table.test.tsx
+++ b/tests/components/Table.test.tsx
@@ -310,6 +310,33 @@ describe("Table", () => {
       expect(page2Button).toHaveClass("custom-page-button");
     });
 
+    it("should show the next page before ellipsis when current is the last visible before it", async () => {
+      const user = userEvent.setup();
+      const largeData = Array.from({ length: 20 }, (_, i) => ({
+        id: i + 1,
+        name: `User ${i + 1}`,
+        email: `user${i + 1}@example.com`,
+        age: 20 + i,
+        tags: ["user"],
+        date: "2023-01-01T00:00:00Z",
+      }));
+
+      render(
+        <Table
+          {...defaultProps}
+          data={largeData}
+          itemsPerPage={2}
+          showPageNumbers={true}
+        />
+      );
+
+      const page3 = screen.getByText("3");
+      await user.click(page3);
+      expect(screen.getByText("4")).toBeInTheDocument();
+      expect(screen.getByText("...")).toBeInTheDocument();
+      expect(screen.getByText("10")).toBeInTheDocument();
+    });
+
     it("should show all pages when total pages <= 5", () => {
       render(<Table {...defaultProps} itemsPerPage={1} showPageNumbers={true} />);
       


### PR DESCRIPTION
# Pull Request

## Description
When the current page is the last visible number before the right ellipsis, the pagination should include the next page before the ellipsis to help users scan forward. Example: with many pages, being on page 3 should render “1 2 3 4 … 10” instead of “1 2 3 … 10”.

**Current Behavior**
On early pages, the window renders a fixed set of numbers and ellipses.
Example with totalPages=10, page=3: “1 2 3 … 10”.

**Expected Behavior**
When the current page is the last visible number before the right ellipsis (boundary), show one additional page before the ellipsis.
Example with totalPages=10, page=3: “1 2 3 4 … 10”.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test improvement

## Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Related Issues
Fixes #(issue number)

## Additional Notes
Any additional information about the PR that reviewers should know.

